### PR TITLE
parsing of apkprotector ZIPs

### DIFF
--- a/zipreader.go
+++ b/zipreader.go
@@ -235,12 +235,15 @@ func OpenZipReader(zipReader io.ReadSeeker) (zr *ZipReader, err error) {
 	if err == nil {
 		for i, zf := range zipinfo.File {
 			if zf.Method != zip.Store && zf.Method != zip.Deflate {
-				// Android code  seems to be treating unknown method as deflate, but
-				// 9a7d5266c223122d24d0061465bf781888984b4b04d9d0df8a76c3e3fe7a3fd0 has method 3217
-				// and the file is really stored, not sure how it works on device.
-				if zf.UncompressedSize64 == zf.CompressedSize64 {
+				// Android code  seems to be treating unknown method as deflate, except for
+				// data extracted with ZipAssetsProvider
+				// 9a7d5266c223122d24d0061465bf781888984b4b04d9d0df8a76c3e3fe7a3fd0
+				switch zf.Name {
+				case "AndroidManifest.xml", "resources.arsc":
 					zipinfo.File[i].Method = zip.Store
-				} else {
+					// 9d055fa3a30b076fdcab3bc9dcf8c1050c548411e88f967b9bd71928ea945fde
+					zipinfo.File[i].CompressedSize64 = zipinfo.File[i].UncompressedSize64
+				default:
 					zipinfo.File[i].Method = zip.Deflate
 				}
 			}

--- a/zipreader.go
+++ b/zipreader.go
@@ -234,9 +234,15 @@ func OpenZipReader(zipReader io.ReadSeeker) (zr *ZipReader, err error) {
 	zipinfo, err = tryReadZip(f)
 	if err == nil {
 		for i, zf := range zipinfo.File {
-			// Android treats anything but 0 as deflate.
 			if zf.Method != zip.Store && zf.Method != zip.Deflate {
-				zipinfo.File[i].Method = zip.Deflate
+				// Android code  seems to be treating unknown method as deflate, but
+				// 9a7d5266c223122d24d0061465bf781888984b4b04d9d0df8a76c3e3fe7a3fd0 has method 3217
+				// and the file is really stored, not sure how it works on device.
+				if zf.UncompressedSize64 == zf.CompressedSize64 {
+					zipinfo.File[i].Method = zip.Store
+				} else {
+					zipinfo.File[i].Method = zip.Deflate
+				}
 			}
 
 			cl := path.Clean(zf.Name)


### PR DESCRIPTION
[parsing of apkprotector ZIPs](https://github.com/csturiale/apkparser/commit/4070a32eaf2c0c372f0c4c59dc5d03540c83b87c)
[fix: zip store method heurestics for AndroidManifest](https://github.com/csturiale/apkparser/commit/e2100ee9c0f586e48702b38cb8cf16d9bfb35f30)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced ZIP archive processing to apply optimized compression handling for vital resource files, ensuring that they maintain their intended integrity during extraction. Other files continue to use the standard compression settings, resulting in improved compatibility and more reliable archive operations for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->